### PR TITLE
add homepage URL to gemspec

### DIFF
--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["palfvin@gmail.com"]
   spec.description   = %q{RSpec extension gem for attribute matching}
   spec.summary       = %q{Provides "its" method formally part of rspec-core}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/rspec/rspec-its"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a home page for your gem.
