### PR TITLE
add expect_its(...) { to ... } as an alternative to its( is_expected.to ... )

### DIFF
--- a/features/expect_its.feature
+++ b/features/expect_its.feature
@@ -1,0 +1,30 @@
+Feature: expecting attribute of subject
+
+  Scenario: specify value of an attribute of a hash
+    Given a file named "example_spec.rb" with:
+    """ruby
+      describe Hash do
+        context "with two items" do
+          subject do
+            {:one => 'one', :two => 'two'}
+          end
+
+          expect_its(:size) { to eq(2) }
+        end
+      end
+      """
+    When I run rspec
+    Then the examples should all pass
+
+  Scenario: failures are correctly reported as coming from the `expect_its` line
+    Given a file named "example_spec.rb" with:
+    """ruby
+      describe Array do
+        context "when first created" do
+          expect_its(:size) { not_to eq(0) }
+        end
+      end
+      """
+    When I run rspec
+    Then the output should contain "Failure/Error: expect_its(:size) { not_to eq(0) }"
+    And the output should not match /#[^\n]*rspec[\x2f]its/

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -1,4 +1,5 @@
 require 'rspec/its/version'
+require 'rspec/its/expect_its'
 require 'rspec/core'
 
 module RSpec

--- a/lib/rspec/its/expect_its.rb
+++ b/lib/rspec/its/expect_its.rb
@@ -1,0 +1,47 @@
+require 'rspec/its/version'
+require 'rspec/core'
+
+module RSpec
+  module ExpectIts
+    # @example
+    #
+    #   # Write this ...
+    #   describe Array do
+    #     expect_its(:size) { to eq(0) }
+    #   end
+    #
+    #   # instead of ...
+    #   describe Array do
+    #     its(:size) { is_expected.to eq(0) }
+    #   end
+
+    def expect_its(attribute, &block)
+      describe(attribute.to_s) do
+        if Array === attribute
+          let(:__its_expect) { expect subject[*attribute] }
+        else
+          let(:__its_expect) do
+            attribute_chain = attribute.to_s.split('.')
+            expect(attribute_chain.inject(subject) do |inner_subject, attr|
+              inner_subject.send(attr)
+            end)
+          end
+        end
+
+        def method_missing(method, *args)
+          __its_expect.send(method, *args)
+        end
+
+        expect_its_caller = caller.select {|file_line| file_line !~ %r(/lib/rspec/its) }
+        example(nil, :caller => expect_its_caller, &block)
+      end
+    end
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.extend RSpec::ExpectIts
+  rspec.backtrace_exclusion_patterns << %r(/lib/rspec/its)
+end
+
+RSpec::SharedContext.send(:include, RSpec::ExpectIts)

--- a/spec/rspec/expect_its_spec.rb
+++ b/spec/rspec/expect_its_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module RSpec
+  describe ExpectIts do
+    describe "#expect_its" do
+      subject do
+        Class.new do
+          def value
+            "new_value"
+          end
+        end.new
+      end
+      expect_its(:value) { to eq "new_value" }
+      expect_its(:value) { not_to eq "old_value" }
+      expect_its(:value) { to_not eq "old_value" }
+    end
+  end
+end


### PR DESCRIPTION
I'm not a fan of the passive tense:

``` ruby
its(:foo) { is_expected.to eq "bar" }
```

so this change allows it to be written

``` ruby
expect_its(:foo) { to eq "bar" }
```

I'm not sure rspec-its is really meant to exist going forward or if it's just hanging around to ensure legacy compatability, but if it is, I'll propose this change.  Thanks.
