### PR TITLE
Support for instance variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ attribute of the attribute of the subject).
 
     its("phone_numbers.size") { should_not eq(0) }
 
+You can use a string with an @ to specify an instance variable which can also be nested if needed.
+
+    its("@my_instance_variable.attribute") { should_not eq(0) }
+
 When the subject is a hash, you can pass in an array with a single key to
 access the value at that key in the hash.
 

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -39,6 +39,24 @@ module RSpec
     #     its("phone_numbers.first") { should eq("555-1212") }
     #   end
     #
+    # The attribute can be an instance variable as a `String`. You can also provide a `String`
+    # with dots, the result is as though you concatenated that `String`
+    # onto the subject in an expression.
+    #
+    # @example
+    #
+    #   class Person
+    #     def initialize
+    #       @accounts_loaded = false
+    #     end
+    #   end
+    #
+    #   describe Person do
+    #     subject { Person.new }
+    #
+    #     its("@accounts_loaded") { is_expected.to be_falsey }
+    #   end
+    #
     # When the subject is a `Hash`, you can refer to the Hash keys by
     # specifying a `Symbol` or `String` in an array.
     #
@@ -86,7 +104,7 @@ module RSpec
           let(:__its_subject) do
             attribute_chain = attribute.to_s.split('.')
             attribute_chain.inject(subject) do |inner_subject, attr|
-              inner_subject.send(attr)
+              attr[0] == '@' ? inner_subject.instance_variable_get(attr) : inner_subject.send(attr)
             end
           end
         end

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -104,7 +104,7 @@ module RSpec
           let(:__its_subject) do
             attribute_chain = attribute.to_s.split('.')
             attribute_chain.inject(subject) do |inner_subject, attr|
-              attr[0] == '@' ? inner_subject.instance_variable_get(attr) : inner_subject.send(attr)
+              attr[0].chr == '@' ? inner_subject.instance_variable_get(attr) : inner_subject.send(attr)
             end
           end
         end

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -59,6 +59,40 @@ module RSpec
 
         end
 
+        context "with nested instance variable" do
+          class DummyAccounts
+            attr_reader :has_loaded
+
+            def initialize
+              @has_loaded = false
+            end
+          end
+
+          subject do
+            Class.new do
+              def initialize
+                @account = DummyAccounts.new
+              end
+
+              def name
+                "John"
+              end
+            end.new
+          end
+
+          its("@account.has_loaded")  { should be_falsey }
+          its("@account.class")       { should eq(DummyAccounts) }
+
+          context "using should_not" do
+            its("@account")           { should_not be_nil }
+          end
+
+          context "using is_expected" do
+            its("@account")           { is_expected.to be_a DummyAccounts }
+          end
+        end
+
+
         context "when it responds to #[]" do
           subject do
             Class.new do


### PR DESCRIPTION
Support for instance variables.  Following is a sample.  Let me know if you have any questions.

The sample class
```ruby
class Person
  def initialize
    @retired = false
  end
end
```

Without the support:
```ruby
describe '.initialize' do
  subject { Person.new }
  it('will not be retired') { expect(subject.instance_varable_get('@retired')).to eq false }
end
```

With the support
```ruby
describe '.initialize' do
  subject { Person.new }
  its('@retired') { is_expected.to eq false }
end
```
