### PR TITLE
Alias is_expected to are_expected

### DIFF
--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -120,6 +120,7 @@ module RSpec
         def is_expected
           expect(__its_subject)
         end
+        alias_method :are_expected, :is_expected
 
         def should(matcher=nil, message=nil)
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(__its_subject, matcher, message)

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -65,6 +65,9 @@ module RSpec
             its("name")          { is_expected.to eq("John") }
           end
 
+          context "using are_expected" do
+            its("name.chars.to_a")    { are_expected.to eq(%w[J o h n]) }
+          end
         end
 
         context "when it responds to #[]" do


### PR DESCRIPTION
When the attribute or method being called from `its` is a plural, the spec doesn't read very well with `is_expected`.

For example:

``` ruby
describe 'something' do
  subject { :foo }
  its(:methods) { is_expected.to include :to_s }
end
```

Using `are_expected` instead of `is_expected` seems to make a little more sense here:

``` ruby
describe 'something' do
  subject { :foo }
  its(:methods) { are_expected.to include :to_s }
end
```
