### PR TITLE
Use #public_send to disallow hitting private methods

### DIFF
--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -112,7 +112,11 @@ module RSpec
           else
             attribute_chain = attribute.to_s.split('.')
             attribute_chain.inject(subject) do |inner_subject, attr|
-              inner_subject.send(attr)
+              if inner_subject.respond_to?(:public_send)
+                inner_subject.public_send(attr)
+              else
+                inner_subject.send(attr)
+              end
             end
           end
         end

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -218,6 +218,34 @@ module RSpec
             expect(status).to eq(:passed)
           end
         end
+
+        describe "with private method" do
+          subject do
+            Class.new do
+              def name
+                private_name
+              end
+              private
+              def private_name
+                "John"
+              end
+            end.new
+          end
+
+          context "when referring indirectly" do
+            its(:name) { is_expected.to eq "John" }
+          end
+
+          context "when attempting to refer directly" do
+            context "it raises an error" do
+              its(:private_name) do
+                expect do
+                  should eq("John")
+                end.to raise_error(NoMethodError) unless RUBY_VERSION == '1.8.7'
+              end
+            end
+          end
+        end
       end
       context "with metadata" do
         context "preserves access to metadata that doesn't end in hash" do


### PR DESCRIPTION
Fixes #28.

If the subject looks like this:

``` ruby
class Person < Struct.new(:name)
  private
  def inner_name
    "Inner #{name}"
  end
end
```

then `its` shouldn't be able to hit the `inner_name` method. The following test:

``` ruby
describe Person do
  subject { Person.new('John') }
  describe '#inner_name' do
    its(:inner_name} { is_expected.to eq 'Inner John' }
  end
end
```

should raise a `NoMethodError`.
