### PR TITLE
README: add Markdown Ruby code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Or install it yourself as:
 
 And require it as:
 
-    require 'rspec/its'
+```ruby
+require 'rspec/its'
+```
 
 ## Usage
 
@@ -28,40 +30,56 @@ subject using `should`, `should_not` or `is_expected`.
 
 `its` accepts a symbol or a string, and a block representing the example.
 
-    its(:size)    { should eq(1) }
-    its("length") { should eq(1) }
+```ruby
+its(:size)    { should eq(1) }
+its("length") { should eq(1) }
+```
 
 You can use a string with dots to specify a nested attribute (i.e. an
 attribute of the attribute of the subject).
 
-    its("phone_numbers.size") { should_not eq(0) }
+```ruby
+its("phone_numbers.size") { should_not eq(0) }
+```
 
 The following expect-style method is also available:
 
-    its(:size) { is_expected.to eq(1) }
-    
+```ruby
+its(:size) { is_expected.to eq(1) }
+```
+
 as is this alias for pluralized use:
 
-    its(:keys) { are_expected.to eq([:key1, :key2]) }
-    
+```ruby
+its(:keys) { are_expected.to eq([:key1, :key2]) }
+```
+
 When the subject implements the `[]` operator, you can pass in an array with a single key to
 refer to the value returned by that operator when passed that key as an argument.
 
-    its([:key]) { is_expected.to eq(value) }
+```ruby
+its([:key]) { is_expected.to eq(value) }
+```
 
 For hashes, multiple keys within the array will result in successive accesses into the hash. For example:
 
-    subject { {key1: {key2: 3} } }
-    its([:key1, :key2]) { is_expected.to eq(3) }
+```ruby
+subject { {key1: {key2: 3} } }
+its([:key1, :key2]) { is_expected.to eq(3) }
+```
 
 For other objects, multiple keys within the array will be passed as separate arguments in a single method call to [], as in:
 
-    subject { Matrix[ [:a, :b], [:c, :d] ] }
-    its([1,1]) { should eq(:d) }
+```ruby
+subject { Matrix[ [:a, :b], [:c, :d] ] }
+its([1,1]) { should eq(:d) }
+```
 
 Metadata arguments are supported.
 
-    its(:size, focus: true) { should eq(1) }
+```ruby
+its(:size, focus: true) { should eq(1) }
+```
 
 ## Contributing
 


### PR DESCRIPTION
This PR adds Markdown Ruby code-highlighting to the README examples for a tiny boost to legibility.