### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
-script: "script/test_all"
 sudo: false
+script: "script/test_all"
 before_install:
   - gem install bundler
 bundler_args: "--standalone --binstubs --without documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+script: "script/test_all"
 sudo: false
 email: false
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 script: "script/test_all"
 sudo: false
 before_install:
-  - gem update --system # update rubygems
-  - gem update bundler
+  - gem install bundler
 bundler_args: "--standalone --binstubs --without documentation"
 rvm:
   - 1.8.7
@@ -18,7 +17,7 @@ rvm:
   - ruby-head
   - ree
   - jruby-18mode
-  - jruby
+  - jruby-9.1.13.0
   - jruby-head
   - rbx
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rvm:
   - ruby-head
   - ree
   - jruby-18mode
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
   - rbx
 matrix:


### PR DESCRIPTION
This PR is about trying to get **JRuby latest release** to run tests in the CI matrix.


  - point to ~`jruby-9.1.13.0`~, ~`jruby-9.1.14.0`~ `jruby-9.1.15.0` so that it can try to run. ~(There was an issue is with `jruby` (the shortname) on rvm - it matches a non-existent `jruby-9.1.13.0200`. See https://github.com/rvm/rvm/issues/4210)~
  - also: `gem install bundler` - when no bundler were there before, this works (this was the case for jruby-head for a while, for example) better than `gem update bundler`
  - also: rvm does a --system update of rubygems built-in, nowadays

Please note: there's an aruba-related failure in actually running, but this PR allows the CI matrix element to at least start.