### PR TITLE
gemspec: Avoid including cucumber.yml

### DIFF
--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rspec/rspec-its"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($/) - %w[cucumber.yml]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This PR avoids distributing the `cucumber.yml` configuration file.

See https://github.com/cucumber/cucumber-rails/issues/346#issuecomment-361167227 