### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     'bug_tracker_uri'   => 'https://github.com/rspec/rspec-its/issues',
     'changelog_uri'     => "https://github.com/rspec/rspec-its/blob/v#{spec.version}/Changelog.md",
-    'documentation_uri' => 'https://rspec.info/documentation/',
+    'documentation_uri' => "https://www.rubydoc.info/gems/rspec-its/#{spec.version}",
     'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri'   => 'https://github.com/rspec/rspec-its',
   }

--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -13,6 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rspec/rspec-its"
   spec.license       = "MIT"
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-its/issues',
+    'changelog_uri'     => "https://github.com/rspec/rspec-its/blob/v#{spec.version}/Changelog.md",
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-its',
+  }
+
   spec.files         = `git ls-files`.split($/) - %w[cucumber.yml]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec-its after the next release.