### PR TITLE
Only ship the necessary libs in the gem artifact

### DIFF
--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => 'https://github.com/rspec/rspec-its',
   }
 
-  spec.files         = `git ls-files`.split($/) - %w[cucumber.yml]
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE.txt} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'rspec-core', '>= 3.0.0'


### PR DESCRIPTION
This aligns this gem with other rspec gems. It strips out the test files
from the gem and only ships the necessary libs for rspec to run. This
reduces the total number of files on disk and the install size for
applications that bundle this gem.

Signed-off-by: Tim Smith <tsmith@chef.io>