### PR TITLE
CI matrix: Update JRuby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ email: false
 before_install:
   - script/update_rubygems_and_install_bundler
 bundler_args: "--standalone --binstubs --without documentation"
-
-# Known version aliases: https://github.com/rvm/rvm/blob/master/config/known
 rvm:
   - 1.8.7
   - 1.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
   - ree
-  - jruby
+  - jruby-9.2.5.0
   - jruby-head
-  - jruby-1.7
+  - jruby-1.7.27
   - rbx-3
 env:
   - JRUBY_OPTS='--dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,25 @@
 language: ruby
 script: "script/test_all"
-sudo: false
 email: false
 before_install:
   - script/update_rubygems_and_install_bundler
 bundler_args: "--standalone --binstubs --without documentation"
+
+# Known version aliases: https://github.com/rvm/rvm/blob/master/config/known
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
   - ree
-  - jruby-9.1.7.0
+  - jruby
   - jruby-head
   - jruby-1.7
   - rbx-3


### PR DESCRIPTION
This PR changes the CI matrix:

- remove the unused `sudo: false` Travis CI setting
- ~change the `rvm` CI matrix settings to use "known versions", with a reference to rvm's implementation: https://github.com/rvm/rvm/blob/master/config/known~
- Update JRuby version numbers

~The benefit is that changes like the one I proposed would be more automatic.~