### PR TITLE
Enable one-liner syntax for expectation blocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 Breaking Changes:
 
 Enhancements:
-* Introduced `is_expected_in_block` and its alias `are_expected_in_block` as a one-liners for block expectations
+* Introduced `will` and `will_not` as one-liners for block expectations
 
 Bug fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,4 @@
-### 1.3.0 / 2019-03-01
-[full changelog](http://github.com/rspec/rspec-its/compare/v1.2.0...v1.3.0)
+### Development
 
 Breaking Changes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+### 1.3.0 / 2019-03-01
+[full changelog](http://github.com/rspec/rspec-its/compare/v1.2.0...v1.3.0)
+
+Breaking Changes:
+
+Enhancements:
+* Introduced `is_expected_in_block` and its alias `are_expected_in_block` as a one-liners for block expectations
+
+Bug fixes:
+
 ### 1.2.0 / 2015-02-06
 [full changelog](http://github.com/rspec/rspec-its/compare/v1.1.0...v1.2.0)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use the `its` method to generate a nested example group with
 a single example that specifies the expected value of an attribute of the
 subject using `should`, `should_not` or `is_expected`.
 The `its` method can also specify the block expectations of an attribute of the
-subject using `is_expected_in_block`.
+subject using `will` or `will_not`.
 
 `its` accepts a symbol or a string, and a block representing the example.
 
@@ -61,13 +61,13 @@ its(:keys) { are_expected.to eq([:key1, :key2]) }
 The following block expect-style method is also available:
 
 ```ruby
-its(:size) { is_expected_in_block.to_not raise_error }
+its(:size) { will_not raise_error }
 ```
 
 as is this alias for pluralized use:
 
 ```ruby
-its(:keys) { are_expected_in_block.to raise_error(NoMethodError) }
+its(:keys) { will raise_error(NoMethodError) }
 ```
 
 When the subject implements the `[]` operator, you can pass in an array with a single key to

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ require 'rspec/its'
 Use the `its` method to generate a nested example group with
 a single example that specifies the expected value of an attribute of the
 subject using `should`, `should_not` or `is_expected`.
+The `its` method can also specify the block expectations of an attribute of the
+subject using `is_expected_in_block`.
 
 `its` accepts a symbol or a string, and a block representing the example.
 
@@ -54,6 +56,18 @@ as is this alias for pluralized use:
 
 ```ruby
 its(:keys) { are_expected.to eq([:key1, :key2]) }
+```
+
+The following block expect-style method is also available:
+
+```ruby
+its(:size) { is_expected_in_block.to_not raise_error }
+```
+
+as is this alias for pluralized use:
+
+```ruby
+its(:keys) { are_expected_in_block.to raise_error(NoMethodError) }
 ```
 
 When the subject implements the `[]` operator, you can pass in an array with a single key to

--- a/features/its.feature
+++ b/features/its.feature
@@ -123,3 +123,51 @@ Feature: attribute of subject
       """
     When I run rspec specifying line number 2
     Then the examples should all pass
+
+  Scenario: specify a method throws an expection
+    Given a file named "example_spec.rb" with:
+      """ruby
+      describe Symbol do
+        subject { :foo }
+        its(:upcase) { will_not raise_error }
+        its(:chomp) { will raise_error(NoMethodError) }
+      end
+      """
+    When I run rspec
+    Then the examples should all pass
+
+  Scenario: specify a method does not throw an expection
+    Given a file named "example_spec.rb" with:
+      """ruby
+      describe Symbol do
+        subject { :foo }
+        its(:chomp) { will_not raise_error }
+      end
+      """
+    When I run rspec
+    Then it should fail with:
+      """
+      Failures:
+
+        1) Symbol chomp should not raise Exception
+           Failure/Error: its(:chomp) { will_not raise_error }
+             expected no Exception, got #<NoMethodError: undefined method `chomp' for :foo:Symbol> with backtrace:
+      """
+
+  Scenario: examples will warn when using non block expectations
+    Given a file named "example_spec.rb" with:
+      """ruby
+      class Klass
+        def terminator
+         "back"
+        end
+      end
+
+      describe Klass do
+        subject { Klass.new }
+        its(:terminator) { will be("back") }
+      end
+      """
+    When I run rspec
+    Then the example should fail
+    And the output should contain "ArgumentError:" and "`will` only supports block expectations"

--- a/features/its.feature
+++ b/features/its.feature
@@ -127,10 +127,16 @@ Feature: attribute of subject
   Scenario: specify a method throws an expection
     Given a file named "example_spec.rb" with:
       """ruby
-      describe Symbol do
-        subject { :foo }
-        its(:upcase) { will_not raise_error }
-        its(:chomp) { will raise_error(NoMethodError) }
+      class Klass
+        def foo
+          true
+        end
+      end
+
+      describe Klass do
+        subject { Klass.new }
+        its(:foo) { will_not raise_error }
+        its(:bar) { will raise_error(NoMethodError) }
       end
       """
     When I run rspec
@@ -139,20 +145,17 @@ Feature: attribute of subject
   Scenario: specify a method does not throw an expection
     Given a file named "example_spec.rb" with:
       """ruby
-      describe Symbol do
-        subject { :foo }
-        its(:chomp) { will_not raise_error }
+      class Klass; end
+
+      describe Klass do
+        subject { Klass.new }
+        its(:foo) { will_not raise_error }
       end
       """
     When I run rspec
-    Then it should fail with:
-      """
-      Failures:
-
-        1) Symbol chomp should not raise Exception
-           Failure/Error: its(:chomp) { will_not raise_error }
-             expected no Exception, got #<NoMethodError: undefined method `chomp' for :foo:Symbol> with backtrace:
-      """
+    Then the example should fail
+    And the output should contain "Failure/Error: its(:foo) { will_not raise_error }"
+    And the output should contain "expected no Exception, got #<NoMethodError: undefined method `foo'"
 
   Scenario: examples will warn when using non block expectations
     Given a file named "example_spec.rb" with:

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -19,3 +19,14 @@ Then /^the example(?:s)? should(?: all)? pass$/ do
   step %q{the output should not contain "0 examples"}
   step %q{the exit status should be 0}
 end
+
+Then(/^the example should fail$/) do
+  step %q{the output should contain "1 failure"}
+  step %q{the exit status should not be 0}
+end
+
+Then(/^the output should contain "(.*?)" and "(.*?)"$/) do |string1, string2|
+  unless [string1, string2].all? { |s| all_output.include?(s) }
+    fail %Q{Both "#{string1}" and "#{string2}" were found in:\n#{all_output}}
+  end
+end

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -70,14 +70,22 @@ module RSpec
     #     its(:size) { is_expected.to eq(0) }
     #   end
     #
-    # With an implicit subject, `is_expected_in_block` can be used as an
-    # alternative to `expect { should matcher }` (e.g. for one-liner use).
-    # An `are_expected_in_block` alias is also supplied.
+    # With an implicit subject, `will` can be used as an alternative
+    # to `expect { subject.attribute }.to matcher` (e.g. for one-liner use).
     #
     # @example
     #
     #   describe Array do
-    #     its(:size) { is_expected_in_block.to_not raise_error }
+    #     its(:foo) { will raise_error(NoMethodError) }
+    #   end
+    #
+    # With an implicit subject, `will_not` can be used as an alternative
+    # to `expect { subject.attribute }.to_not matcher` (e.g. for one-liner use).
+    #
+    # @example
+    #
+    #   describe Array do
+    #     its(:size) { will_not raise_error }
     #   end
     #
     # You can pass more than one argument on the `its` block to add
@@ -133,10 +141,13 @@ module RSpec
         end
         alias_method :are_expected, :is_expected
 
-        def is_expected_in_block
-          expect { __its_subject }
+        def will(matcher=nil, message=nil)
+          expect { __its_subject }.to matcher, message
         end
-        alias_method :are_expected_in_block, :is_expected_in_block
+
+        def will_not(matcher=nil, message=nil)
+          expect { __its_subject }.to_not matcher, message
+        end
 
         def should(matcher=nil, message=nil)
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(__its_subject, matcher, message)

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -70,6 +70,16 @@ module RSpec
     #     its(:size) { is_expected.to eq(0) }
     #   end
     #
+    # With an implicit subject, `is_expected_in_block` can be used as an
+    # alternative to `expect { should matcher }` (e.g. for one-liner use).
+    # An `are_expected_in_block` alias is also supplied.
+    #
+    # @example
+    #
+    #   describe Array do
+    #     its(:size) { is_expected_in_block.to_not raise_error }
+    #   end
+    #
     # You can pass more than one argument on the `its` block to add
     # some metadata to the generated example
     #
@@ -122,6 +132,11 @@ module RSpec
           expect(__its_subject)
         end
         alias_method :are_expected, :is_expected
+
+        def is_expected_in_block
+          expect { __its_subject }
+        end
+        alias_method :are_expected_in_block, :is_expected_in_block
 
         def should(matcher=nil, message=nil)
           RSpec::Expectations::PositiveExpectationHandler.handle_matcher(__its_subject, matcher, message)

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -142,14 +142,16 @@ module RSpec
         alias_method :are_expected, :is_expected
 
         def will(matcher=nil, message=nil)
-          raise ArgumentError, "`will` only supports block expectations" \
-            unless matcher.supports_block_expectations?
+          unless matcher.supports_block_expectations?
+            raise ArgumentError, "`will` only supports block expectations"
+          end
           expect { __its_subject }.to matcher, message
         end
 
         def will_not(matcher=nil, message=nil)
-          raise ArgumentError, "`will_not` only supports block expectations" \
-            unless matcher.supports_block_expectations?
+          unless matcher.supports_block_expectations?
+            raise ArgumentError, "`will_not` only supports block expectations"
+          end
           expect { __its_subject }.to_not matcher, message
         end
 

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -142,10 +142,14 @@ module RSpec
         alias_method :are_expected, :is_expected
 
         def will(matcher=nil, message=nil)
+          raise ArgumentError, "`will` only supports block expectations" \
+            unless matcher.supports_block_expectations?
           expect { __its_subject }.to matcher, message
         end
 
         def will_not(matcher=nil, message=nil)
+          raise ArgumentError, "`will_not` only supports block expectations" \
+            unless matcher.supports_block_expectations?
           expect { __its_subject }.to_not matcher, message
         end
 

--- a/lib/rspec/its/version.rb
+++ b/lib/rspec/its/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Its
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/rspec/its/version.rb
+++ b/lib/rspec/its/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Its
-    VERSION = "1.3.0"
+    VERSION = "1.2.0"
   end
 end

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -69,8 +69,16 @@ module RSpec
             its("name") { is_expected.to eq("John") }
           end
 
+          context "using is_expected_in_block" do
+            its("name") { is_expected_in_block.to_not raise_error }
+          end
+
           context "using are_expected" do
             its("name.chars.to_a") { are_expected.to eq(%w[J o h n]) }
+          end
+
+          context "using are_expected_in_block" do
+            its("name.chars.to_a") { are_expected_in_block.to_not raise_error }
           end
         end
 
@@ -103,6 +111,14 @@ module RSpec
                   should eq(64)
                 end.to raise_error(NoMethodError)
               end
+
+              context "using is_expected_in_block" do
+                its(:age) { is_expected_in_block.to raise_error(NoMethodError) }
+              end
+
+              context "using are_expected_in_block" do
+                its(:ages) { are_expected_in_block.to raise_error(NoMethodError) }
+              end
             end
           end
 
@@ -117,6 +133,10 @@ module RSpec
               its([:not_here]) { should be_nil }
               its([:a, :ghost]) { should be_nil }
               its([:deep, :ghost]) { expect { should eq("missing") }.to raise_error(NoMethodError) }
+
+              context "using is_expected_in_block" do
+                its([:deep, :ghost]) { is_expected_in_block.to raise_error(NoMethodError) }
+              end
             end
           end
         end
@@ -129,6 +149,10 @@ module RSpec
               expect do
                 should eq("Symbol: a")
               end.to raise_error(NoMethodError)
+            end
+
+            context "using is_expected_in_block" do
+              its([:a]) { is_expected_in_block.to raise_error(NoMethodError) }
             end
           end
         end

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -304,6 +304,8 @@ module RSpec
             def increment
               @count += 1
             end
+
+            def noop; end
           end.new
         end
 
@@ -312,6 +314,24 @@ module RSpec
         its(:increment) { will change { subject.count }.from(0).to(1) }
         its(:increment) { will change { subject.count }.by_at_least(1) }
         its(:increment) { will change { subject.count }.by_at_most(1) }
+
+        its(:noop) { will_not change { subject.count } }
+        its(:noop) { will_not change { subject.count }.from(0) }
+
+        its(:increment) do
+          expect { will_not change { subject.count }.by(0) }.to \
+            raise_error(NotImplementedError, '`expect { }.not_to change { }.by()` is not supported')
+        end
+
+        its(:increment) do
+          expect { will_not change { subject.count }.by_at_least(2) }.to \
+            raise_error(NotImplementedError, '`expect { }.not_to change { }.by_at_least()` is not supported')
+        end
+
+        its(:increment) do
+          expect { will_not change { subject.count }.by_at_most(3) }.to \
+            raise_error(NotImplementedError, '`expect { }.not_to change { }.by_at_most()` is not supported')
+        end
       end
 
       context "with output capture" do
@@ -334,6 +354,26 @@ module RSpec
 
         its(:noop) { will_not output("some error").to_stderr }
         its(:noop) { will_not output("some output").to_stdout }
+      end
+
+      context "#will with non block expectations" do
+        subject do
+          Class.new do
+            def terminator
+              "back"
+            end
+          end.new
+        end
+
+        its(:terminator) do
+          expect { will be("back") }.to \
+            raise_error(ArgumentError, '`will` only supports block expectations')
+        end
+
+        its(:terminator) do
+          expect { will_not be("back") }.to \
+            raise_error(ArgumentError, '`will_not` only supports block expectations')
+        end
       end
     end
   end


### PR DESCRIPTION
When the attribute or method being called from `its` is expected to raise or not raise an error the  the spec doesn't read very well with `expect { should }`.

For example:

```ruby
describe 'something' do
  subject { :foo }
  its(:upcase) { expect { should }.to_not raise_error }
  its(:chomp) { expect { should }.to raise_error(NoMethodError) }
end
```

Using `is_expected_in_block` instead seems to make a little more sense here:

```ruby
describe 'something' do
  subject { :foo }
  its(:upcase) { is_expected_in_block.to_not raise_error }
  its(:chomp) { is_expected_in_block.to raise_error(NoMethodError) }
end
```