### PR TITLE
Constants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### Development
+
+Enchancements:
+
+* Ability to fetch class constants
+
 ### 1.3.0 / 2019-04-09
 [full changelog](http://github.com/rspec/rspec-its/compare/v1.2.0...v1.3.0)
 

--- a/features/its.feature
+++ b/features/its.feature
@@ -84,6 +84,38 @@ Feature: attribute of subject
     When I run rspec
     Then the examples should all pass
 
+ Scenario: specify value of a described_class's constant
+   Given a file named "example_spec.rb" with:
+     """ruby
+     class Klass
+       FOO = :bar
+     end
+
+     describe Klass do
+       describe 'constants' do
+         its(:FOO) { should eq(:bar) }
+       end
+     end
+     """
+   When I run rspec
+   Then the examples should all pass
+
+  Scenario: specify value of a subject's constant
+    Given a file named "example_spec.rb" with:
+      """ruby
+      class Klass
+        Foo = :bar
+      end
+
+      describe 'constants' do
+        subject { Klass }
+
+        its(:Foo) { should eq(:bar) }
+      end
+      """
+    When I run rspec
+    Then the examples should all pass
+
  Scenario: failures are correctly reported as coming from the `its` line
     Given a file named "example_spec.rb" with:
       """ruby

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -39,6 +39,26 @@ module RSpec
     #     its("phone_numbers.first") { should eq("555-1212") }
     #   end
     #
+    # When the attribute starts with an upper case letter, `its` will look
+    # for a constant within either `subject` (if it responds to `const_get`)
+    # or `described_class`.
+    #
+    # @example
+    #
+    #   class Klass
+    #     FOO = :bar
+    #   end
+    #
+    #   describe Klass do
+    #     its(:FOO) { should eq(:bar) }
+    #   end
+    #
+    #   describe 'class constants' do
+    #     subject { Klass }
+    #
+    #     its(:FOO) { should eq(:bar) }
+    #   end
+    #
     # When the subject is a `Hash`, you can refer to the Hash keys by
     # specifying a `Symbol` or `String` in an array.
     #
@@ -128,6 +148,8 @@ module RSpec
             else
               subject[*attribute]
             end
+          elsif %r([[:upper:]]).match(attribute.to_s[0])
+            (subject.respond_to?(:const_get) ? subject : described_class).const_get(attribute)
           else
             attribute_chain = attribute.to_s.split('.')
             attribute_chain.inject(subject) do |inner_subject, attr|

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -45,6 +45,15 @@ module RSpec
           its(:nil_value) { should be_nil }
         end
 
+        context 'with constant name' do
+          subject do
+            Class.new do
+              const_set(:CONST_NAME, 1)
+            end
+          end
+          its(:CONST_NAME) { should eq(1) }
+        end
+
         context "with nested attributes" do
           subject do
             Class.new do


### PR DESCRIPTION
At our project we have unit tests for all class constants to ensure their values are not modified.
We use `rspec-its` but currently it doesn't provide the ability to fetch constants from `described_class` or `subject`. So here it is.

#### Examples

Sample class:

```ruby
class Klass                                                                                       
  FOO = :bar                                                                                      
end                                                                                               
```

No `subject` specified, constant is fetched from `described_class`:

```ruby
describe Klass do
  its(:FOO) { is_expected.to eq(:bar)
end
```

`subject` explicitly specified:

```ruby
describe 'constants' do
  subject { Klass }

  its(:FOO) { is_expected.to eq(:bar) }
end
```
