### PR TITLE
Update Aruba to version 0.14.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ end
 # test coverage
 # gem 'simplecov', :require => false
 
+gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
+
 gem 'coveralls', :require => false, :platform => :mri_20
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,22 +2,14 @@ require 'aruba/cucumber'
 require 'rspec/core'
 require 'rspec/its'
 
-Before do
-  if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
-    @aruba_timeout_seconds = 60
-  else
-    @aruba_timeout_seconds = 10
-  end
-end
-
 Aruba.configure do |config|
-  config.before_cmd do |cmd|
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+  config.before(:command) do |cmd|
+    cmd.environment['JRUBY_OPTS'] = "-X-C #{ENV['JRUBY_OPTS']}" # disable JIT since these processes are so short lived
   end
 end if RUBY_PLATFORM == 'java'
 
 Aruba.configure do |config|
-  config.before_cmd do |cmd|
-    set_env('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
+  config.before(:command) do |cmd|
+    cmd.environment['RBXOPT'] = "-Xint=true #{ENV['RBXOPT']}" # disable JIT since these processes are so short lived
   end
 end if defined?(Rubinius)

--- a/rspec-its.gemspec
+++ b/rspec-its.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler',  '> 1.3.0'
   spec.add_development_dependency 'rake',     '~> 10.1.0'
   spec.add_development_dependency 'cucumber', '~> 1.3.8'
-  spec.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
+  spec.add_development_dependency "aruba",    "~> 0.14.12"
 
 end


### PR DESCRIPTION
- Update aruba dependency version
- Update aruba configuration to fix deprecations
- Pin contracts to a compatible version on Ruby 1.8