### PR TITLE
Bump to RSpec 3.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 %w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-  branch = ENV.fetch('BRANCH','3-1-maintenance')
+  branch = ENV.fetch('BRANCH','3-9-maintenance')
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path

--- a/features/its.feature
+++ b/features/its.feature
@@ -28,7 +28,7 @@ Feature: attribute of subject
       Person
         with one phone number (555-1212)
           phone_numbers.first
-            should eq "555-1212"
+            is expected to eq "555-1212"
       """
 
   Scenario: specify value of an attribute of a hash


### PR DESCRIPTION
The one test failure was caused by change in RSpec 3.9:

https://github.com/rspec/rspec-expectations/pull/1080