### PR TITLE
Check all versions of RSpec against rspec-its and fix 3.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# In order to install old Rubies, we need to use old Ubuntu distibution.
+dist: trusty
 language: ruby
 script: "script/test_all"
 email: false
@@ -12,9 +14,10 @@ rvm:
   - 2.1
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
   - ruby-head
   - ree
   - jruby-9.2.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,38 @@ rvm:
 env:
   - JRUBY_OPTS='--dev'
 matrix:
+  include:
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-9-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-8-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-7-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-6-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-5-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-4-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-3-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-2-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-1-maintenance"
+    - rvm: 2.7.0
+      env:
+        - BRANCH="3-0-maintenance"
+
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,12 @@ source 'https://rubygems.org'
 gemspec
 
 %w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-  branch = ENV.fetch('BRANCH','3-1-maintenance')
+  branch = ENV.fetch('BRANCH','3-0-maintenance')
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
   else
-    gem lib, :git => "git://github.com/rspec/#{lib}.git",
-             :branch => branch
+    gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
 

--- a/features/its.feature
+++ b/features/its.feature
@@ -1,5 +1,6 @@
 Feature: attribute of subject
 
+  @pre-3-9
   Scenario: specify value of a nested attribute
     Given a file named "example_spec.rb" with:
       """ruby
@@ -29,6 +30,38 @@ Feature: attribute of subject
         with one phone number (555-1212)
           phone_numbers.first
             should eq "555-1212"
+      """
+
+  @post-3-9
+  Scenario: specify value of a nested attribute
+    Given a file named "example_spec.rb" with:
+      """ruby
+      class Person
+        attr_reader :phone_numbers
+        def initialize
+          @phone_numbers = []
+        end
+      end
+
+      describe Person do
+        context "with one phone number (555-1212)"do
+          subject do
+            person = Person.new
+            person.phone_numbers << "555-1212"
+            person
+          end
+
+          its("phone_numbers.first") { should eq("555-1212") }
+        end
+      end
+      """
+    When I run rspec with the documentation option
+    Then the output should contain:
+      """
+      Person
+        with one phone number (555-1212)
+          phone_numbers.first
+            is expected to eq "555-1212"
       """
 
   Scenario: specify value of an attribute of a hash

--- a/script/test_all
+++ b/script/test_all
@@ -14,10 +14,16 @@ bin/rspec spec --format progress --profile
 
 echo "Running cucumber specs"
 
+if ruby -e 'exit(ENV.fetch("BRANCH","3-0-maintenance") =~ /3-[0-8]-maintenance/ ? 0 : 1)'; then
+  TAGS="--tags @pre-3-9"
+else
+  TAGS="--tags @post-3-9"
+fi;
+
 if ruby -e "exit(defined?(RUBY_PLATFORM) && RUBY_PLATFORM == 'java')"; then
   # This is JRUBY which requires this one weird path trick...
   PATH="${PWD}/bin:$PATH" \
-  bundle exec cucumber --strict
+  bundle exec cucumber --strict $TAGS
 else
-  bundle exec cucumber --strict
+  bundle exec cucumber --strict $TAGS
 fi;


### PR DESCRIPTION
This updates Ruby to latest version(s), adds a matrix of rspec versions, and gates the expected output based on rspec version.