### PR TITLE
Proposal: Inform user when testing a private method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,3 @@ gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
 gem 'coveralls', :require => false, :platform => :mri_20
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')
-
-gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,5 @@ gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
 gem 'coveralls', :require => false, :platform => :mri_20
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')
+
+gem 'pry'

--- a/features/its.feature
+++ b/features/its.feature
@@ -51,7 +51,7 @@ Feature: attribute of subject
             person
           end
 
-          its("phone_numbers.first") { should eq("555-1212") }
+          its("phone_numbers.first") { is_expected.to eq("555-1212") }
         end
       end
       """
@@ -61,7 +61,7 @@ Feature: attribute of subject
       Person
         with one phone number (555-1212)
           phone_numbers.first
-            should eq "555-1212"
+            is expected to eq "555-1212"
       """
 
   Scenario: specify value of an attribute of a hash

--- a/features/its.feature
+++ b/features/its.feature
@@ -61,7 +61,7 @@ Feature: attribute of subject
       Person
         with one phone number (555-1212)
           phone_numbers.first
-            is expected to eq "555-1212"
+            should eq "555-1212"
       """
 
   Scenario: specify value of an attribute of a hash

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -1,13 +1,13 @@
 require 'rspec/its/version'
 require 'rspec/core'
 
-RSpec.deprecate <<EOS
-rspec-its deprecates calling _send_ in favour of _public_send_ internally.
-This change will be introduced with version 2.0.
-Maybe you're testing private methods in your test suite without your intention.
-If you need more information about which test is affected,
-set `config.its_raise_errors_for_private_method_calling = true`
-EOS
+# RSpec.deprecate <<EOS
+# rspec-its deprecates calling _send_ in favour of _public_send_ internally.
+# This change will be introduced with version 2.0.
+# Maybe you're testing private methods in your test suite without your intention.
+# If you need more information about which test is affected,
+# set `config.its_raise_errors_for_private_method_calling = true`
+# EOS
 
 module RSpec
   module Its
@@ -140,15 +140,8 @@ module RSpec
             attribute_chain = attribute.to_s.split('.')
             attribute_chain.inject(subject) do |inner_subject, attr|
 
-              if RSpec.configuration.its_raise_errors_for_private_method_calling
-
-                # respond_to? only looks in the public method space
-                # TODO Check NoMethodError
-                # TODO Check if inner_subject some kind of const
-                # inner_subject.method_defined?(attr) && !inner_subject.respond_to?(attr)
-                if !inner_subject.respond_to?(attr)
-                  raise 'Testing private method' + attr
-                end
+              if inner_subject.private_methods(false).include?(attr.to_sym)
+                RSpec.deprecate("Testing private method #{attr}", :call_site   => its_caller.first)
               end
 
               inner_subject.send(attr)

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -1,5 +1,12 @@
 require 'spec_helper'
 
+# class RSpec::Core::Formatters::DeprecationFormatter
+#   Formatters.register self, :baem
+
+#   def baem(notification)
+#     output << 'baem'
+#   end
+# end
 module RSpec
   describe Its do
     describe "#its" do
@@ -11,31 +18,32 @@ module RSpec
       end
 
       context "raises error when calling a private method" do
-        around(:each) do |example|
-          RSpec.configuration.its_raise_errors_for_private_method_calling = true
-          example.run
-          RSpec.configuration.its_raise_errors_for_private_method_calling = false
-        end
-
         subject do
           Class.new do
             private
 
             def name
+              'Maria'
             end
 
             def self.name
+              'Maria'
             end
             private_class_method :name
           end
         end
 
+        before(:each) do
+          # expect(RSpec).to receive(:deprecate)
+          #                    .with('Testing private method name is deprecated', anything)
+        end
+
         context 'on an instance' do
-          its('new.name') { will raise_error }
+          its('new.name') { should eq('Maria') }
         end
 
         context 'on a class' do
-          its('name') { will raise_error }
+          its('name') { should eq('Maria') }
         end
       end
 

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -9,6 +9,19 @@ module RSpec
           its([]) { expect(described_class).to be Its }
         end
       end
+      context "" do
+        subject do
+          Class.new do
+            private
+
+            def name
+              'Maria'
+            end
+          end.new
+        end
+
+        its(:name, :focus) { should eq('Maria') }
+      end
       context "with explicit subject" do
         subject do
           Class.new do

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -9,19 +9,36 @@ module RSpec
           its([]) { expect(described_class).to be Its }
         end
       end
-      context "" do
+
+      context "raises error when calling a private method" do
+        around(:each) do |example|
+          RSpec.configuration.its_raise_errors_for_private_method_calling = true
+          example.run
+          RSpec.configuration.its_raise_errors_for_private_method_calling = false
+        end
+
         subject do
           Class.new do
             private
 
             def name
-              'Maria'
             end
-          end.new
+
+            def self.name
+            end
+            private_class_method :name
+          end
         end
 
-        its(:name, :focus) { should eq('Maria') }
+        context 'on an instance' do
+          its('new.name') { will raise_error }
+        end
+
+        context 'on a class' do
+          its('name') { will raise_error }
+        end
       end
+
       context "with explicit subject" do
         subject do
           Class.new do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.order = 'random'
 
+  # config.raise_errors_for_deprecations!
+
   # config.its_private_method_debug = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,6 @@ end
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.order = 'random'
+
+  # config.its_private_method_debug = true
 end


### PR DESCRIPTION
Hello guys,

please take a look about this feature proposal
for safely migrate from *send* to *public_send*
mentioned https://github.com/rspec/rspec-its/issues/28

I'd like to know if this would be an approach you would accept.
Then I would finalize this little piece.

Cheers