### PR TITLE
Fix example usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,6 @@ jobs:
           - ruby: jruby-9.2.13.0
             env:
               JRUBY_OPTS: "--dev"
-          - ruby: jruby-9.1.17.0
-            bundler: 1
-            os: ubuntu-18.04
-            env:
-              JRUBY_OPTS: "--dev"
           # Compatibility builds
           - ruby: '3.2'
             name_extra: "against RSpec 3.12"
@@ -123,6 +118,9 @@ jobs:
             tag: ghcr.io/rspec/docker-ci:1.9.3
           - version: "JRuby 1.7"
             tag: ghcr.io/rspec/docker-ci:jruby-1.7
+          - version: "JRuby 9.1.17.0"
+            tag: ghcr.io/rspec/docker-ci:jruby-9.1.17.0
+            options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       LEGACY_CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,17 +110,19 @@ jobs:
   legacy:
     name: Legacy Ruby Builds (${{ matrix.container.version }})
     runs-on: ubuntu-20.04
-    container: ${{ matrix.container.tag }}
+    container:
+      image: ${{ matrix.container.tag }}
+      options: ${{ matrix.container.options || '--add-host github-complains-if-this-is-empty.com:127.0.0.1' }}
     strategy:
       fail-fast: false
       matrix:
         container:
           - version: "2.0"
-            tag: rspec/ci:2.0.0
+            tag: ghcr.io/rspec/docker-ci:2.0.0
           - version: "1.9.3"
-            tag: rspec/ci:1.9.3
+            tag: ghcr.io/rspec/docker-ci:1.9.3
           - version: "JRuby 1.7"
-            tag: rspec/ci:jruby-1.7
+            tag: ghcr.io/rspec/docker-ci:jruby-1.7
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       LEGACY_CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
           - version: "JRuby 1.7"
             tag: rspec/ci:jruby-1.7
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       LEGACY_CI: true
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,11 @@ gemspec
 %w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
   branch = ENV.fetch('BRANCH','main')
   library_path = File.expand_path("../../#{lib}", __FILE__)
+
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
+  elsif lib == 'rspec'
+    gem 'rspec', :git => "https://github.com/rspec/rspec-metagem.git", :branch => branch
   else
     gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
   end

--- a/lib/rspec/its.rb
+++ b/lib/rspec/its.rb
@@ -1,6 +1,8 @@
 require 'rspec/its/version'
 require 'rspec/core'
 
+RSpec::Core::ExampleGroup.define_example_method :__its_example
+
 module RSpec
   module Its
 
@@ -166,7 +168,7 @@ module RSpec
         options << {} unless options.last.kind_of?(Hash)
         options.last.merge!(:caller => its_caller)
 
-        example(nil, *options, &block)
+        __its_example(nil, *options, &block)
 
       end
     end

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -270,7 +270,6 @@ module RSpec
         end
 
         its(:good) { will_not raise_error }
-        its(:bad) { will raise_error }
         its(:bad) { will raise_error(ArgumentError) }
         its(:bad) { will raise_error("message") }
         its(:bad) { will raise_error(ArgumentError, "message") }

--- a/spec/rspec/its_spec.rb
+++ b/spec/rspec/its_spec.rb
@@ -9,6 +9,7 @@ module RSpec
           its([]) { expect(described_class).to be Its }
         end
       end
+
       context "with explicit subject" do
         subject do
           Class.new do
@@ -374,6 +375,20 @@ module RSpec
           expect { will_not be("back") }.to \
             raise_error(ArgumentError, '`will_not` only supports block expectations')
         end
+      end
+
+      context "when example is redefined" do
+        subject do
+          Class.new do
+            def will_still_work; true; end
+          end.new
+        end
+
+        def self.example(*_args)
+          raise
+        end
+
+        its(:will_still_work) { is_expected.to be true }
       end
     end
   end


### PR DESCRIPTION
If example is overridden, it can cause errors, whilst example is an expected alias for creating groups, there is an api that allows us to define our own, and given we already do a bunch of `__its_*` method creation, might as well do that here too.